### PR TITLE
responsive-home-artworks

### DIFF
--- a/Style_RR.css
+++ b/Style_RR.css
@@ -106,17 +106,6 @@ h1 {
   font-size: 18px;
 }
 
-/* Aligner cards ecran 13" */
-@media (max-width: 1300px) {
-  .container2 {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
-    flex-wrap: nowrap;
-  }
-}
-
 /* Bouton spécifique pour les œuvres d'art */
 .bouton_artworks {
   display: inline-flex;
@@ -464,8 +453,7 @@ h1 {
 
 @media (max-width: 768px) {
   /* Explore and artworks container */
-  .explore,
-  .container2 {
+  .explore {
     flex-direction: column;
     align-items: center;
     text-align: left;

--- a/home.css
+++ b/home.css
@@ -45,17 +45,6 @@
   color: white;
 }
 
-/* Section des cartes d'œuvres d'art */
-.container2 {
-  margin-top: 4rem;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  row-gap: 1.5rem;
-  column-gap: 1.5rem;
-  justify-items: center;
-  align-items: stretch;
-}
-
 /* Media queries pour mobile */
 @media (max-width: 768px) {
   /* Explore buttons */
@@ -75,10 +64,5 @@
 
   .container1 {
     width: 100%;
-  }
-
-  .container2 {
-    margin-top: 5rem;
-    grid-template-columns: repeat(1, 1fr);
   }
 }

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       </section>
 
       <!-- Section des dernières œuvres d'art -->
-      <section class="container2">
+      <section class="paintings_container">
         <!-- Card Foster Wallace -->
         <a href="artworks/foster-wallace-2024.html" class="gallery_card">
           <div class="gallery_img_container">


### PR DESCRIPTION
—————————————
             Avant 
—————————————
<img width="482" alt="avant" src="https://github.com/user-attachments/assets/e9fc741c-f818-4c92-994b-20ea79ab99bb">
—————————————
             Après 
—————————————
<img width="482" alt="après" src="https://github.com/user-attachments/assets/1f784ec0-8ed2-4b4f-a27f-168288f830f2">
